### PR TITLE
Fix script src

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -73,8 +73,8 @@ class ChunkManifestPlugin {
             mainTemplate.outputOptions.chunkFilename = oldChunkFilename;
 
             return source.replace(
-              `"${chunkManifestFilename}"`,
-              `window['${this.options.manifestVariable}']['${chunkId}']`,
+              'script.src = jsonpScriptSrc(chunkId);',
+              `script.src = __webpack_require__.p + window['${this.options.manifestVariable}'][${chunkId}];`
             );
           }
         },


### PR DESCRIPTION
The __CHUNK_MANIFEST__ variable doesn't seem to be used anymore and instead webpack uses a jsonpScriptSrc function to generate the url for a chunk. So the supplied manifest variable was not currently being used.

This replaces the call to that function with our already provided chunk filename.